### PR TITLE
Removed label, allowBackup from <application> tag

### DIFF
--- a/udark/underdark/src/main/AndroidManifest.xml
+++ b/udark/underdark/src/main/AndroidManifest.xml
@@ -14,10 +14,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Keeping label and allowBackup attribute in the library manifest cause issues in the user applications and are not required.
- AllowBackup by default is turned off. Any app which references underdark will have it changed to true, which might cause side effects
- Label is usually overridden by main application manifest, however in builds with flavours it causes merge conflict and build failure (which is still possible to solve by adding tools:ignore="android:label")

My pull request should make your library more easier to integrate with less side effects
