### PR TITLE
Update targetSDK, buildTools, support library and maven plugin

### DIFF
--- a/udark/build.gradle
+++ b/udark/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robolectric:robolectric-gradle-plugin:1.1.0'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5"
 

--- a/udark/gradle/wrapper/gradle-wrapper.properties
+++ b/udark/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 09 19:22:18 MSK 2016
+#Sat Dec 24 12:46:35 EET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/udark/udapp/build.gradle
+++ b/udark/udapp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "io.underdark.app"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
 
@@ -32,7 +32,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     //compile(name:'underdark-release', ext:'aar')
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
     compile project(':underdark')
     compile 'org.slf4j:slf4j-api:1.7.12'
 }

--- a/udark/underdark/build.gradle
+++ b/udark/underdark/build.gradle
@@ -20,15 +20,15 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
         //classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5"
     }
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
     resourcePrefix "underdark__"
 
     // http://stackoverflow.com/a/24910671/1449965
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 24
         versionCode ud_versionCode
         versionName ud_version
     }


### PR DESCRIPTION
Note that during build a warning appeared.

Warning:The `android.dexOptions.incremental` property is deprecated and
it has no effect on the build process.